### PR TITLE
Support for multi-process tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ main:
 	mkdir -p bin
 	gcc src/*.c src/process/*.c -Wall -I include -o bin/unpack `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`
 
+debug:
+	mkdir -p bin
+	gcc src/*.c src/process/*.c -Wall -g -I include -o bin/unpack `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`
+
 .PHONY: tools
 
 tools:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ main:
 tools:
 	mkdir -p bin
 	gcc tools/vmi_table_walk.c -Wall -I include -o bin/vmi-table-walk `pkg-config --cflags --libs libvmi`
-	gcc tools/table_monitor.c src/monitor.c -Wall -I include -o bin/table-monitor `pkg-config --cflags --libs libvmi glib-2.0`
+	gcc tools/table_monitor.c src/monitor.c -Wall -I include -o bin/table-monitor `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`
 	gcc tools/rekall_linux.c src/rekall_parser.c -Wall -I include -o bin/rekall-linux `pkg-config --cflags --libs json-glib-1.0`
 	gcc tools/rekall_windows.c src/rekall_parser.c -Wall -I include -o bin/rekall-windows `pkg-config --cflags --libs json-glib-1.0`
 	gcc tools/cr3_tracker.c src/rekall_parser.c src/process/*.c -Wall -I include -o bin/cr3-tracker `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ One of the following must be provided:
 The current output of VMI-Unpack is very basic. Every time the target process
 writes data to a page and then executes it, that page will be extracted as a
 layer. Layers are written to the provided output directory in the form
-`<layer>-<rip>.bin` where `<layer>` starts at 0 and increments with each newly
+`<pid>-<layer>-<rip>.bin` where `<layer>` starts at 0 and increments with each newly
 extracted layer and `<rip>` is the value of the program counter when the layer
 is first executed. This value can also be interpreted as the virtual address
 the layer starts at.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ One of the following must be provided:
     -p <pid>                 unpack process with provided PID
     -n <process_name>        unpack process with provided name
 
-Options arguments:
+Optional arguments:
     -f                       also follow children created by target process
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Required arguments:
 One of the following must be provided:
     -p <pid>                 unpack process with provided PID
     -n <process_name>        unpack process with provided name
+
+Options arguments:
+    -f                       also follow children created by target process
 ```
 
 ## Output

--- a/include/dump.h
+++ b/include/dump.h
@@ -36,6 +36,7 @@ GQueue *dump_queue;
 uint64_t layer_num;
 
 typedef struct {
+    vmi_pid_t pid;
     reg_t rip;
     char *buff;
     uint64_t size;
@@ -60,8 +61,9 @@ void stop_dump_thread();
  * @param buffer A pointer to the buffer to dump. This should be left allocated
  * and the worker thread will handle freeing it.
  * @param size The size of the buffer.
+ * @param pid The PID of the process that executed the page.
  * @param rip The value of the RIP register when this layer was executed.
  */
-void add_to_dump_queue(char *buffer, uint64_t size, reg_t rip);
+void add_to_dump_queue(char *buffer, uint64_t size, vmi_pid_t pid, reg_t rip);
 
 #endif

--- a/include/dump.h
+++ b/include/dump.h
@@ -33,7 +33,7 @@ pthread_t dump_worker;
 char *dump_output_dir;
 sem_t dump_sem;
 GQueue *dump_queue;
-uint64_t layer_num;
+GHashTable *pid_layer; // key: vmi_pid_t, value: uint64_t current layer
 
 typedef struct {
     vmi_pid_t pid;

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -48,8 +48,8 @@ typedef enum {
     PAGE_CAT_1GB_FRAME,
 } page_cat_t;
 
-// args: vmi, event, page category
-typedef void (*page_table_monitor_cb_t)(vmi_instance_t,vmi_event_t*,page_cat_t);
+// args: vmi, event, pid, page category
+typedef void (*page_table_monitor_cb_t)(vmi_instance_t, vmi_event_t*, vmi_pid_t, page_cat_t);
 
 typedef struct {
     addr_t paddr;

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -37,6 +37,7 @@ vmi_event_t page_table_monitor_ss;
 vmi_event_t page_table_monitor_cr3;
 GHashTable *page_cb_events;  // key: vmi_pid_t, value: page_cb_event_t
 GHashTable *page_p2pid;      // key: addr_t (4KB aligned), value: vmi_pid_t
+GHashTable *trapped_pages;   // key: addr_t, value: uint8_t (page type)
 GSList *pending_page_rescan; // queue of table rescans
 GSList *cr3_callbacks;       // list of CR3 write callbacks
 
@@ -55,7 +56,6 @@ typedef void (*page_table_monitor_cb_t)(vmi_instance_t, vmi_event_t*, vmi_pid_t,
 
 typedef struct {
     addr_t paddr;
-    GHashTable *cb_table;
     vmi_pid_t pid;
     page_cat_t cat;
 } pending_rescan_t;
@@ -65,7 +65,6 @@ typedef struct {
     reg_t cr3;
     uint8_t flags;
     page_table_monitor_cb_t cb;
-    GHashTable *trapped_pages; // key: addr_t, value: uint8_t (page type)
 } page_cb_event_t;
 
 /**

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -34,9 +34,11 @@ bool page_table_monitor_init;
 vmi_instance_t monitor_vmi;
 vmi_event_t page_table_monitor_event;
 vmi_event_t page_table_monitor_ss;
-GHashTable *page_cb_events; // key: vmi_pid_t, value: page_cb_event_t
-GHashTable *page_p2pid; // key: addr_t (4KB aligned), value: vmi_pid_t
+vmi_event_t page_table_monitor_cr3;
+GHashTable *page_cb_events;  // key: vmi_pid_t, value: page_cb_event_t
+GHashTable *page_p2pid;      // key: addr_t (4KB aligned), value: vmi_pid_t
 GSList *pending_page_rescan; // queue of table rescans
+GSList *cr3_callbacks;       // list of CR3 write callbacks
 
 typedef enum {
     PAGE_CAT_PML4,
@@ -60,6 +62,8 @@ typedef struct {
 
 typedef struct {
     vmi_pid_t pid;
+    reg_t cr3;
+    uint8_t flags;
     page_table_monitor_cb_t cb;
     GHashTable *trapped_pages; // key: addr_t, value: uint8_t (page type)
 } page_cb_event_t;
@@ -68,8 +72,10 @@ typedef struct {
  * Initializes the page table monitor.
  *
  * @param vmi a libVMI instance
+ *
+ * @return 0 on success, not 0 otherwise.
  */
-void monitor_init(vmi_instance_t vmi);
+int monitor_init(vmi_instance_t vmi);
 
 /**
  * Destroys the page table monitor.
@@ -87,8 +93,19 @@ void monitor_destroy(vmi_instance_t vmi);
  * @param pid a PID to monitor
  * @param cb a function to invoke when new pages are created
  * @param filter only invoke cb when the new page matches this filter
+ * @param optional flags:
+ *
+ *     MONITOR_FOLLOW_REMAPPING - If this flag is set, the monitor will continue to track the process
+ *                                even if its page table is changed (i.e. PID is the same but CR3 is
+ *                                modified). Linux's execve is an example of how this can happen.
+ *
+ *     MONITOR_FOLLOW_CHILDREN  - If this flag is set, the monitor will also track children created
+ *                                by the process.
  */
-void monitor_add_page_table(vmi_instance_t vmi, vmi_pid_t pid, page_table_monitor_cb_t cb);
+void monitor_add_page_table(vmi_instance_t vmi, vmi_pid_t pid, page_table_monitor_cb_t cb, uint8_t flags);
+
+#define MONITOR_FOLLOW_REMAPPING (1U << 0)
+#define MONITOR_FOLLOW_CHILDREN  (1U << 1)
 
 /**
  * Removes a registered callback.
@@ -97,5 +114,26 @@ void monitor_add_page_table(vmi_instance_t vmi, vmi_pid_t pid, page_table_monito
  * @param pid a PID
  */
 void monitor_remove_page_table(vmi_instance_t vmi, vmi_pid_t pid);
+
+/**
+ * Registers a CR3 callback.
+ *
+ * LibVMI only allows one CR3 write event to be registered at a time.
+ * The monitor needs such an event, so other callbacks of this type
+ * cannot be registered once the monitor is initialized. This method
+ * allows others to still get CR3 write events, although in a
+ * restricted manner. Specifically, the reponse returned by the
+ * callback will be ignored.
+ *
+ * @param cb a libVMI event callback
+ */
+void monitor_add_cr3(event_callback_t cb);
+
+/**
+ * Removes a previously registered CR3 write callback.
+ *
+ * @param cb a libVMI event callback
+ */
+void monitor_remove_cr3(event_callback_t cb);
 
 #endif

--- a/include/rekall_parser.h
+++ b/include/rekall_parser.h
@@ -34,12 +34,14 @@ typedef struct {
     gint64 kthread_process;
     gint64 eprocess_pname;
     gint64 eprocess_pid;
+    gint64 eprocess_parent_pid;
 } windows_rekall_t;
 
 typedef struct {
     gint64 current_task;
     gint64 task_struct_comm;
     gint64 task_struct_pid;
+    gint64 task_struct_parent;
 } linux_rekall_t;
 
 /**

--- a/include/vmi/process.h
+++ b/include/vmi/process.h
@@ -53,7 +53,7 @@ void process_vmi_destroy();
  *
  * @param vmi A vmi_instance_t for the guest VM to introspect.
  *
- * @return The PID of the current process.
+ * @return The PID of the current process or 0 if it could not be determined.
  */
 vmi_pid_t (*vmi_current_pid)(vmi_instance_t vmi, vmi_event_t *event);
 
@@ -66,16 +66,28 @@ vmi_pid_t (*vmi_current_pid)(vmi_instance_t vmi, vmi_event_t *event);
  */
 char *(*vmi_current_name)(vmi_instance_t vmi, vmi_event_t *event);
 
+/**
+ * Gets the parent PID for the current process.
+ *
+ * @param vmi A vmi_instance_t for the guest VM to introspect.
+ *
+ * @return The PID of the parent of the current process or 0 if it could not be
+ * determined.
+ */
+vmi_pid_t (*vmi_current_parent_pid)(vmi_instance_t vmi, vmi_event_t *event);
+
 /* LINUX */
 
 linux_rekall_t process_vmi_linux_rekall;
 vmi_pid_t vmi_current_pid_linux(vmi_instance_t vmi, vmi_event_t *event);
 char *vmi_current_name_linux(vmi_instance_t vmi, vmi_event_t *event);
+vmi_pid_t vmi_current_parent_pid_linux(vmi_instance_t vmi, vmi_event_t *event);
 
 /* WINDOWS */
 
 windows_rekall_t process_vmi_windows_rekall;
 vmi_pid_t vmi_current_pid_windows(vmi_instance_t vmi, vmi_event_t *event);
 char *vmi_current_name_windows(vmi_instance_t vmi, vmi_event_t *event);
+vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -94,7 +94,7 @@ void usage(char *name) {
     printf("    -p <pid>                 unpack process with provided PID\n");
     printf("    -n <process_name>        unpack process with provided name\n");
     printf("\n");
-    printf("Options arguments:\n");
+    printf("Optional arguments:\n");
     printf("    -f                       also follow children created by target process\n");
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ static void close_handler(int sig) {
 /**
  * Callback that's invoked when a process tries to write then execute.
  */
-void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, page_cat_t page_cat) {
+void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat) {
 
     uint64_t page_size;
 
@@ -72,12 +72,13 @@ void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, page_cat_t page_cat) {
         return;
     }
 
+    // Extract the W2X page from the guest VM
     addr_t paddr = (event->mem_event.gfn << 12) + event->mem_event.offset;
     uint64_t dump_size = page_size - event->mem_event.offset;
-    char * buffer = (char *) malloc(dump_size);
+    char * buffer = (char *) malloc(dump_size); // TODO - Cache allocate page sizes for better performance
     vmi_read_pa(vmi, paddr, (void *) buffer, dump_size);
 
-    add_to_dump_queue(buffer, dump_size, event->x86_regs->rip);
+    add_to_dump_queue(buffer, dump_size, pid, event->x86_regs->rip);
 }
 
 void usage(char *name) {

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -247,7 +247,7 @@ event_response_t monitor_handler(vmi_instance_t vmi, vmi_event_t *event) {
 
     if (*cat_ptr == PAGE_CAT_4KB_FRAME || *cat_ptr == PAGE_CAT_2MB_FRAME || *cat_ptr == PAGE_CAT_1GB_FRAME) {
         if (event->mem_event.out_access & VMI_MEMACCESS_X) {
-            cb_event->cb(vmi, event, *cat_ptr);
+            cb_event->cb(vmi, event, *pid_ptr, *cat_ptr);
             vmi_set_mem_event(vmi, event->mem_event.gfn, VMI_MEMACCESS_W, 0);
         } else if (event->mem_event.out_access & VMI_MEMACCESS_W) {
             vmi_set_mem_event(vmi, event->mem_event.gfn, VMI_MEMACCESS_X, 0);

--- a/src/process/process.c
+++ b/src/process/process.c
@@ -36,6 +36,7 @@ bool process_vmi_init_linux(char *rekall_filepath) {
 
     vmi_current_pid = vmi_current_pid_linux;
     vmi_current_name = vmi_current_name_linux;
+    vmi_current_parent_pid = vmi_current_parent_pid_linux;
 
     process_vmi_ready = 1;
     return 1;
@@ -50,6 +51,7 @@ bool process_vmi_init_windows(char *rekall_filepath) {
 
     vmi_current_pid = vmi_current_pid_windows;
     vmi_current_name = vmi_current_name_windows;
+    vmi_current_parent_pid = vmi_current_parent_pid_windows;
 
     process_vmi_ready = 1;
     return 1;

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -51,6 +51,10 @@ addr_t vmi_current_process_windows(vmi_instance_t vmi, vmi_event_t *event) {
 
     addr_t process;
     addr_t thread = vmi_current_thread_windows(vmi, event);
+
+    if (!thread)
+        return 0;
+
     addr_t kthread = thread + process_vmi_windows_rekall.kthread_process;
     if (vmi_read_addr_va(vmi, kthread, 0, &process) != VMI_SUCCESS)
         return 0;
@@ -66,6 +70,9 @@ vmi_pid_t vmi_current_pid_windows(vmi_instance_t vmi, vmi_event_t *event) {
     }
 
     addr_t process = vmi_current_process_windows(vmi, event);
+
+    if (!process)
+        return 0;
 
     vmi_pid_t pid;
     addr_t eprocess_pid = process + process_vmi_windows_rekall.eprocess_pid;
@@ -83,7 +90,31 @@ char *vmi_current_name_windows(vmi_instance_t vmi, vmi_event_t *event) {
     }
 
     addr_t process = vmi_current_process_windows(vmi, event);
+
+    if (!process)
+        return NULL;
+
     addr_t eprocess_pname = process + process_vmi_windows_rekall.eprocess_pname;
 
     return vmi_read_str_va(vmi, eprocess_pname, 0);
+}
+
+vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event) {
+
+    if (!process_vmi_ready) {
+        fprintf(stderr, "ERROR: Windows Process VMI - Not initialized\n");
+        return 0;
+    }
+
+    addr_t process = vmi_current_process_windows(vmi, event);
+
+    if (!process)
+        return 0;
+
+    vmi_pid_t parent_pid;
+    addr_t eprocess_parent_pid = process + process_vmi_windows_rekall.eprocess_parent_pid;
+    if (vmi_read_32_va(vmi, eprocess_parent_pid, 0, (uint32_t *) &parent_pid) != VMI_SUCCESS)
+        return 0;
+
+    return parent_pid;
 }

--- a/src/rekall_parser.c
+++ b/src/rekall_parser.c
@@ -105,6 +105,18 @@ bool parse_rekall_linux(linux_rekall_t *rekall, char *json_file) {
     }
     rekall->task_struct_pid = json_reader_get_int_value(reader);
     json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // task_struct->real_parent offset
+    if (!json_reader_read_member(reader, "real_parent")) {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['real_parent']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0)) {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['real_parent'][0]\n");
+        return 0;
+    }
+    rekall->task_struct_parent = json_reader_get_int_value(reader);
 
     g_object_unref(reader);
     g_object_unref(parser);
@@ -122,19 +134,6 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file) {
     }
 
     JsonReader *reader = json_reader_new(json_parser_get_root(parser));
-
-    // current_task offset
-    //if (!json_reader_read_member(reader, "$CONSTANTS")) {
-    //    fprintf(stderr, "ERROR: Rekall Parser - Failed to locate \n");
-    //    return 0;
-    //}
-    //if (!json_reader_read_member(reader, "current_task")) {
-    //    fprintf(stderr, "ERROR: Rekall Parser - Failed to locate \n");
-    //    return 0;
-    //}
-    //rekall->current_task = json_reader_get_int_value(reader);
-    //json_reader_end_member(reader);
-    //json_reader_end_member(reader);
 
     // kpcr->prcb
     if (!json_reader_read_member(reader, "$STRUCTS")) {
@@ -219,11 +218,11 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file) {
         return 0;
     }
     if (!json_reader_read_member(reader, "ImageFileName")) {
-        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _ImageFileName[1]['ImageFileName']\n");
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['ImageFileName']\n");
         return 0;
     }
     if (!json_reader_read_element(reader, 0)) {
-        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _ImageFileName[1]['ImageFileName'][0]\n");
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['ImageFileName'][0]\n");
         return 0;
     }
     rekall->eprocess_pname = json_reader_get_int_value(reader);
@@ -232,18 +231,27 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file) {
 
     // eprocess_pid
     if (!json_reader_read_member(reader, "UniqueProcessId")) {
-        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _ImageFileName[1]['UniqueProcessId']\n");
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['UniqueProcessId']\n");
         return 0;
     }
     if (!json_reader_read_element(reader, 0)) {
-        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _ImageFileName[1]['UniqueProcessId'][0]\n");
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['UniqueProcessId'][0]\n");
         return 0;
     }
     rekall->eprocess_pid = json_reader_get_int_value(reader);
     json_reader_end_member(reader);
     json_reader_end_member(reader);
-    json_reader_end_member(reader);
-    json_reader_end_member(reader);
+
+    // eprocess_parent_pid
+    if (!json_reader_read_member(reader, "InheritedFromUniqueProcessId")) {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['InheritedFromUniqueProcessId']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0)) {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['InheritedFromUniqueProcessId'][0]\n");
+        return 0;
+    }
+    rekall->eprocess_parent_pid = json_reader_get_int_value(reader);
 
     g_object_unref(reader);
     g_object_unref(parser);

--- a/tools/cr3_tracker.c
+++ b/tools/cr3_tracker.c
@@ -42,9 +42,10 @@ static void close_handler(int sig) {
 event_response_t monitor_cr3(vmi_instance_t vmi, vmi_event_t *event) {
 
     vmi_pid_t pid = vmi_current_pid(vmi, event);
+    vmi_pid_t parent_pid = vmi_current_parent_pid(vmi, event);
     char *name = vmi_current_name(vmi, event);
 
-    printf("VCPU: %d PID: %d NAME: %s\n", event->vcpu_id, pid, name);
+    printf("VCPU: %d PID: %d NAME: %s PARENT: %d\n", event->vcpu_id, pid, name, parent_pid);
 
     free(name);
     return VMI_EVENT_RESPONSE_NONE;

--- a/tools/rekall_linux.c
+++ b/tools/rekall_linux.c
@@ -36,8 +36,9 @@ int main(int argc, char *argv[]) {
     if (!parse_rekall_linux(&rekall, argv[1])) {
         printf("Failed to parse rekall file\n");
     } else {
-        printf("current_thread = %ld, comm = %ld, pid = %ld\n", rekall.current_task,
-                rekall.task_struct_comm, rekall.task_struct_pid);
+        printf("current_thread = %ld, comm = %ld, pid = %ld parent = %ld\n",
+                rekall.current_task, rekall.task_struct_comm, rekall.task_struct_pid,
+                rekall.task_struct_parent);
     }
 
     return EXIT_SUCCESS;

--- a/tools/rekall_windows.c
+++ b/tools/rekall_windows.c
@@ -36,9 +36,9 @@ int main(int argc, char *argv[]) {
     if (!parse_rekall_windows(&rekall, argv[1])) {
         printf("Failed to parse rekall file\n");
     } else {
-        printf("kprc_prcb = %ld, kpcr_currentthread = %ld, kthread_process = %ld, eprocess_pname = %ld, eprocess_pid = %ld\n",
+        printf("kprc_prcb = %ld, kpcr_currentthread = %ld, kthread_process = %ld, eprocess_pname = %ld, eprocess_pid = %ld eprocess_parent_pid = %ld\n",
                 rekall.kpcr_prcb, rekall.kprcb_currentthread, rekall.kthread_process, rekall.eprocess_pname,
-                rekall.eprocess_pid);
+                rekall.eprocess_pid, rekall.eprocess_parent_pid);
     }
 
     return EXIT_SUCCESS;

--- a/tools/table_monitor.c
+++ b/tools/table_monitor.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
 
     vmi_pause_vm(vmi);
     monitor_init(vmi);
-    monitor_add_page_table(vmi, atoi(argv[2]), w2x_cb);
+    monitor_add_page_table(vmi, atoi(argv[2]), w2x_cb, MONITOR_FOLLOW_REMAPPING);
     vmi_resume_vm(vmi);
 
     // Main loop

--- a/tools/table_monitor.c
+++ b/tools/table_monitor.c
@@ -38,7 +38,7 @@ static void close_handler(int sig) {
 /**
  * Callback that's invoked when a process tries to write then execute.
  */
-void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, page_cat_t cat) {
+void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t cat) {
 
     printf("Caught write then execute! [EIP=0x%lx]\n", event->x86_regs->rip);
 }


### PR DESCRIPTION
Users can now use the `-f` flag to track children created by the target process.