### PR TITLE
Ether-like header fixing for Windows PEs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ debug:
 tools:
 	mkdir -p bin
 	gcc tools/vmi_table_walk.c -Wall -I include -o bin/vmi-table-walk `pkg-config --cflags --libs libvmi`
-	gcc tools/table_monitor.c src/monitor.c -Wall -I include -o bin/table-monitor `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`
+	gcc tools/table_monitor.c src/monitor.c src/rekall_parser.c src/process/*.c -Wall -I include -o bin/table-monitor `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`
 	gcc tools/rekall_linux.c src/rekall_parser.c -Wall -I include -o bin/rekall-linux `pkg-config --cflags --libs json-glib-1.0`
 	gcc tools/rekall_windows.c src/rekall_parser.c -Wall -I include -o bin/rekall-windows `pkg-config --cflags --libs json-glib-1.0`
 	gcc tools/cr3_tracker.c src/rekall_parser.c src/process/*.c -Wall -I include -o bin/cr3-tracker `pkg-config --cflags --libs libvmi glib-2.0 json-glib-1.0`

--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ repository and run `make`.
 ./bin/unpack [options]
 
 Required arguments:
-    -d <domain_name>         name of VM to unpack from
-    -r <rekall_file>         path to rekall file
-    -o <output_dir>          directory to dump layers into
+    -d <domain_name>         Name of VM to unpack from.
+    -r <rekall_file>         Path to rekall file.
+    -o <output_dir>          Directory to dump layers into.
 
 One of the following must be provided:
-    -p <pid>                 unpack process with provided PID
-    -n <process_name>        unpack process with provided name
+    -p <pid>                 Unpack process with provided PID.
+    -n <process_name>        Unpack process with provided name.
 
 Optional arguments:
-    -f                       also follow children created by target process
+    -f                       Also follow children created by target process.
+    -i <exec_bin>            Fix layer headers based on provided executable.
+                             This image is NOT executable.
 ```
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -74,10 +74,9 @@ Optional arguments:
 
 ## Output
 
-The current output of VMI-Unpack is very basic. Every time the target process
-writes data to a page and then executes it, that page will be extracted as a
-layer. Layers are written to the provided output directory in the form
-`<pid>-<layer>-<rip>.bin` where `<layer>` starts at 0 and increments with each newly
-extracted layer and `<rip>` is the value of the program counter when the layer
-is first executed. This value can also be interpreted as the virtual address
-the layer starts at.
+Every time the target process writes data to a page and then executes it, the memory
+segment that page belongs to will be extracted as a layer. Layers are written to the
+provided output directory in the form `<pid>-<layer>-<rip>.bin` where `<layer>`
+starts at 0 and increments with each newly extracted layer and `<rip>` is the value
+of the program counter when the layer is first executed. This value can also be
+interpreted as the virtual address the layer starts at.

--- a/include/output/output_parser.h
+++ b/include/output/output_parser.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Carter Yagemann
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef OUTPUT_PARSER_H
+#define OUTPUT_PARSER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <output/pe.h>
+
+typedef enum
+{
+    UNKNOWN,
+    DOS,
+} image_type;
+
+extern image_type base_image_type;
+extern void *base_image_raw;
+
+/**
+ * Parses the image at the provided filepath and attempts to identify its type.
+ * This method must be called before any of the other parser methods can be
+ * used.
+ *
+ * @param base_image The path to an image file to use for initialization.
+ *
+ * @return 1 if successful, otherwise 0.
+ */
+bool output_init_parser(char *base_image);
+
+/**
+ * Fixes the layer's header in a similar manner to how Ether does it.
+ * The exact fixes depends on the base image's type, but generally involves
+ * repointing the entry to the newly unpacked address and fixing the section
+ * headers to match the base image.
+ *
+ * Note that the entry parameter should be a RVA, i.e. a virtual address
+ * relative to the virtual address the image was loaded into. In other words:
+ *
+ *     entry = (executed virtual address - base virtual address)
+ *
+ * @param layer a pointer to the layer.
+ * @param layer_size the size of this layer.
+ * @param entry the address that was executed when this layer was dumped.
+ */
+void (*output_fix_header)(void *layer, ssize_t layer_size, uint64_t entry);
+
+/* DOS */
+
+typedef struct
+{
+    PIMAGE_DOS_HEADER dos_header;
+    PIMAGE_NT_HEADERS nt_header;
+    PIMAGE_OPTIONAL_HEADER opt_header;
+    PIMAGE_FILE_HEADER file_header;
+    PIMAGE_SECTION_HEADER sect_header;
+} mapped_pe_t;
+
+mapped_pe_t base_image_pe;
+
+bool parse_dos_header(void *buffer, mapped_pe_t *pe);
+void output_fix_dos_header(void *layer, ssize_t layer_size, uint64_t entry);
+
+#endif

--- a/include/output/pe.h
+++ b/include/output/pe.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017 Carter Yagemann
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef WINDOWS_PE_H
+#define WINDOWS_PE_H
+
+typedef unsigned int     DWORD;
+typedef int              BOOL;
+typedef unsigned char    BYTE;
+typedef short            WORD;
+typedef float            FLOAT;
+typedef long             LONG;
+typedef FLOAT           *PFLOAT;
+typedef BOOL            *PBOOL;
+typedef BOOL            *LPBOOL;
+typedef BYTE            *PBYTE;
+typedef BYTE            *LPBYTE;
+typedef int             *PINT;
+typedef int             *LPINT;
+typedef WORD            *PWORD;
+typedef WORD            *LPWORD;
+typedef long            *LPLONG;
+typedef DWORD           *PDWORD;
+typedef DWORD           *LPDWORD;
+typedef void            *LPVOID;
+typedef const void      *LPCVOID;
+
+#define IMAGE_DOS_SIGNATURE                 0x5A4D      // MZ
+#define IMAGE_NT_SIGNATURE                  0x00004550  // PE00
+
+#define IMAGE_NUMBEROF_DIRECTORY_ENTRIES     16
+#define IMAGE_SIZEOF_SHORT_NAME               8
+#define IMAGE_SIZEOF_SECTION_HEADER          40
+
+typedef struct _IMAGE_DOS_HEADER        // DOS .EXE header
+{
+    WORD    e_magic;                     // Magic number
+    WORD    e_cblp;                      // Bytes on last page of file
+    WORD    e_cp;                        // Pages in file
+    WORD    e_crlc;                      // Relocations
+    WORD    e_cparhdr;                   // Size of header in paragraphs
+    WORD    e_minalloc;                  // Minimum extra paragraphs needed
+    WORD    e_maxalloc;                  // Maximum extra paragraphs needed
+    WORD    e_ss;                        // Initial (relative) SS value
+    WORD    e_sp;                        // Initial SP value
+    WORD    e_csum;                      // Checksum
+    WORD    e_ip;                        // Initial IP value
+    WORD    e_cs;                        // Initial (relative) CS value
+    WORD    e_lfarlc;                    // File address of relocation table
+    WORD    e_ovno;                      // Overlay number
+    WORD    e_res[4];                    // Reserved words
+    WORD    e_oemid;                     // OEM identifier (for e_oeminfo)
+    WORD    e_oeminfo;                   // OEM information; e_oemid specific
+    WORD    e_res2[10];                  // Reserved words
+    DWORD   e_lfanew;                    // File address of new exe header
+} __attribute__((packed)) IMAGE_DOS_HEADER, *PIMAGE_DOS_HEADER;
+
+typedef struct _IMAGE_DATA_DIRECTORY
+{
+    DWORD   VirtualAddress;
+    DWORD   Size;
+} __attribute__((packed)) IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+
+typedef struct _IMAGE_OPTIONAL_HEADER
+{
+    //
+    // Standard fields.
+    //
+
+    WORD    Magic;
+    BYTE    MajorLinkerVersion;
+    BYTE    MinorLinkerVersion;
+    DWORD   SizeOfCode;
+    DWORD   SizeOfInitializedData;
+    DWORD   SizeOfUninitializedData;
+    DWORD   AddressOfEntryPoint;
+    DWORD   BaseOfCode;
+    DWORD   BaseOfData;
+
+    //
+    // NT additional fields.
+    //
+
+    DWORD   ImageBase;
+    DWORD   SectionAlignment;
+    DWORD   FileAlignment;
+    WORD    MajorOperatingSystemVersion;
+    WORD    MinorOperatingSystemVersion;
+    WORD    MajorImageVersion;
+    WORD    MinorImageVersion;
+    WORD    MajorSubsystemVersion;
+    WORD    MinorSubsystemVersion;
+    DWORD   Win32VersionValue;
+    DWORD   SizeOfImage;
+    DWORD   SizeOfHeaders;
+    DWORD   CheckSum;
+    WORD    Subsystem;
+    WORD    DllCharacteristics;
+    DWORD   SizeOfStackReserve;
+    DWORD   SizeOfStackCommit;
+    DWORD   SizeOfHeapReserve;
+    DWORD   SizeOfHeapCommit;
+    DWORD   LoaderFlags;
+    DWORD   NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+} __attribute__((packed)) IMAGE_OPTIONAL_HEADER32, *PIMAGE_OPTIONAL_HEADER32;
+
+typedef IMAGE_OPTIONAL_HEADER32 IMAGE_OPTIONAL_HEADER;
+typedef IMAGE_OPTIONAL_HEADER32 *PIMAGE_OPTIONAL_HEADER;
+
+
+typedef struct _IMAGE_FILE_HEADER
+{
+    WORD    Machine;
+    WORD    NumberOfSections;
+    DWORD   TimeDateStamp;
+    DWORD   PointerToSymbolTable;
+    DWORD   NumberOfSymbols;
+    WORD    SizeOfOptionalHeader;
+    WORD    Characteristics;
+} __attribute__((packed)) IMAGE_FILE_HEADER, *PIMAGE_FILE_HEADER;
+
+typedef struct _IMAGE_SECTION_HEADER
+{
+    BYTE    Name[IMAGE_SIZEOF_SHORT_NAME];
+    union
+    {
+        DWORD   PhysicalAddress;
+        DWORD   VirtualSize;
+    } __attribute__((packed)) Misc;
+    DWORD   VirtualAddress;
+    DWORD   SizeOfRawData;
+    DWORD   PointerToRawData;
+    DWORD   PointerToRelocations;
+    DWORD   PointerToLinenumbers;
+    WORD    NumberOfRelocations;
+    WORD    NumberOfLinenumbers;
+    DWORD   Characteristics;
+} __attribute__((packed)) IMAGE_SECTION_HEADER, *PIMAGE_SECTION_HEADER;
+
+typedef struct _IMAGE_NT_HEADERS
+{
+    DWORD Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER32 OptionalHeader;
+} __attribute__((packed)) IMAGE_NT_HEADERS32, *PIMAGE_NT_HEADERS32;
+
+typedef IMAGE_NT_HEADERS32 IMAGE_NT_HEADERS;
+typedef IMAGE_NT_HEADERS32 *PIMAGE_NT_HEADERS;
+
+
+#endif

--- a/include/rekall_parser.h
+++ b/include/rekall_parser.h
@@ -28,15 +28,21 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
-// TODO - Extend windows rekall with MM data
 typedef struct
 {
     gint64 kpcr_prcb;
     gint64 kprcb_currentthread;
     gint64 kthread_process;
+    gint64 kprocess_pdbase;
     gint64 eprocess_pname;
     gint64 eprocess_pid;
     gint64 eprocess_parent_pid;
+    gint64 eprocess_tasks;
+    gint64 eprocess_vadroot;
+    gint64 mmvad_leftchild;
+    gint64 mmvad_rightchild;
+    gint64 mmvad_startingvpn;
+    gint64 mmvad_endingvpn;
 } windows_rekall_t;
 
 typedef struct

--- a/include/rekall_parser.h
+++ b/include/rekall_parser.h
@@ -28,6 +28,7 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
+// TODO - Extend windows rekall with MM data
 typedef struct
 {
     gint64 kpcr_prcb;
@@ -44,6 +45,13 @@ typedef struct
     gint64 task_struct_comm;
     gint64 task_struct_pid;
     gint64 task_struct_parent;
+    gint64 task_struct_mm;
+    gint64 task_struct_tasks;
+    gint64 mm_struct_mmap;
+    gint64 mm_struct_pgd;
+    gint64 vm_area_struct_vm_start;
+    gint64 vm_area_struct_vm_end;
+    gint64 vm_area_struct_vm_next;
 } linux_rekall_t;
 
 /**

--- a/include/vmi/process.h
+++ b/include/vmi/process.h
@@ -32,6 +32,12 @@
 
 bool process_vmi_ready;
 
+typedef struct
+{
+    addr_t base_va; // Base virtual address of memory segment
+    ssize_t size;   // Size of the memory segment
+} mem_seg_t;
+
 /**
  * Initializes the functions in this header file.
  *
@@ -52,6 +58,7 @@ void process_vmi_destroy();
  * vmi_dtb_to_pid because it doesn't walk the entire process list.
  *
  * @param vmi A vmi_instance_t for the guest VM to introspect.
+ * @param event A vmi_event_t to give the method context.
  *
  * @return The PID of the current process or 0 if it could not be determined.
  */
@@ -61,6 +68,7 @@ vmi_pid_t (*vmi_current_pid)(vmi_instance_t vmi, vmi_event_t *event);
  * Gets the current process' name.
  *
  * @param vmi A vmi_instance_t for the guest VM to introspect.
+ * @param event A vmi_event_t to give the method context.
  *
  * @return The current process' name or NULL if it could not be determined.
  */
@@ -70,11 +78,26 @@ char *(*vmi_current_name)(vmi_instance_t vmi, vmi_event_t *event);
  * Gets the parent PID for the current process.
  *
  * @param vmi A vmi_instance_t for the guest VM to introspect.
+ * @param event A vmi_event_t to give the method context.
  *
  * @return The PID of the parent of the current process or 0 if it could not be
  * determined.
  */
 vmi_pid_t (*vmi_current_parent_pid)(vmi_instance_t vmi, vmi_event_t *event);
+
+/**
+ * Gets information on the memory segment that the given address belongs to in
+ * the current process.
+ *
+ * @param vmi A vmi_instance_t for the guest VM to introspect.
+ * @param event A vmi_event_t to give the method context.
+ * @param addr The virtual address to look up.
+ *
+ * @return A struct containing information about the found memory segment. If
+ *         the address isn't mapped, the returned struct will contain a size
+ *         of 0.
+ */
+mem_seg_t (*vmi_current_find_segment)(vmi_instance_t vmi, vmi_event_t *event, addr_t addr);
 
 /* LINUX */
 
@@ -82,6 +105,7 @@ linux_rekall_t process_vmi_linux_rekall;
 vmi_pid_t vmi_current_pid_linux(vmi_instance_t vmi, vmi_event_t *event);
 char *vmi_current_name_linux(vmi_instance_t vmi, vmi_event_t *event);
 vmi_pid_t vmi_current_parent_pid_linux(vmi_instance_t vmi, vmi_event_t *event);
+mem_seg_t vmi_current_find_segment_linux(vmi_instance_t vmi, vmi_event_t *event, addr_t addr);
 
 /* WINDOWS */
 
@@ -89,5 +113,6 @@ windows_rekall_t process_vmi_windows_rekall;
 vmi_pid_t vmi_current_pid_windows(vmi_instance_t vmi, vmi_event_t *event);
 char *vmi_current_name_windows(vmi_instance_t vmi, vmi_event_t *event);
 vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event);
+mem_seg_t vmi_current_find_segment_windows(vmi_instance_t vmi, vmi_event_t *event, addr_t addr);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,10 @@ void w2x_cb(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t pa
     }
 
     vmi_read_va(vmi, vma.base_va, pid, vma.size, buffer, &dump_size);
+
+    if (base_image)
+        output_fix_header(buffer, dump_size, event->x86_regs->rip);
+
     add_to_dump_queue(buffer, dump_size, pid, event->x86_regs->rip);
 }
 

--- a/src/output_parser.c
+++ b/src/output_parser.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017 Carter Yagemann
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include <output/output_parser.h>
+#include <output/pe.h>
+
+image_type base_image_type = UNKNOWN;
+void *base_image_raw = NULL;
+
+bool output_init_parser(char *base_image)
+{
+    if (base_image_raw)
+    {
+        free(base_image_raw);
+        base_image_raw = NULL;
+    }
+
+    if (!base_image)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Filepath for base image is null.\n");
+        return 0;
+    }
+
+    struct stat image_stat;
+    if (stat(base_image, &image_stat))
+    {
+        fprintf(stderr, "ERROR: Output Parser - Failed to stat %s\n", base_image);
+        return 0;
+    }
+
+    FILE *base_image_fp = fopen(base_image, "r");
+    if (!base_image_fp)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Failed to open %s\n", base_image);
+        return 0;
+    }
+
+    base_image_raw = malloc(image_stat.st_size);
+    if (!base_image_raw)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Failed to allocate memory for base image\n");
+        return 0;
+    }
+
+    if (fread(base_image_raw, 1, image_stat.st_size, base_image_fp) != image_stat.st_size)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Failed to copy base image into memory\n");
+        return 0;
+    }
+    fclose(base_image_fp);
+
+    // Is this a DOS header?
+    if (parse_dos_header(base_image_raw, &base_image_pe))
+    {
+        base_image_type = DOS;
+        output_fix_header = output_fix_dos_header;
+        return 1;
+    }
+
+    fprintf(stderr, "ERROR: Output Parser - Base image is an unsupported type of executable\n");
+    return 0;
+}
+
+bool parse_dos_header(void *buffer, mapped_pe_t *pe)
+{
+    // Locate DOS header and check magic number
+    pe->dos_header = (PIMAGE_DOS_HEADER) buffer;
+    if (pe->dos_header->e_magic != IMAGE_DOS_SIGNATURE)
+        return 0;
+
+    // Locate NT header and check signature
+    base_image_pe.nt_header = (PIMAGE_NT_HEADERS)(base_image_raw + pe->dos_header->e_lfanew);
+    if (base_image_pe.nt_header->Signature != IMAGE_NT_SIGNATURE)
+        return 0;
+
+    pe->opt_header = (PIMAGE_OPTIONAL_HEADER) & (pe->nt_header->OptionalHeader);
+    pe->sect_header = (PIMAGE_SECTION_HEADER)((unsigned long) pe->nt_header + sizeof(IMAGE_NT_HEADERS));
+    return 1;
+}
+
+void output_fix_dos_header(void *layer, ssize_t layer_size, uint64_t entry)
+{
+    if (base_image_type != DOS)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Parser not initialized, cannot fix header\n");
+        return;
+    }
+
+    if (!layer)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Layer is null, cannot fix header\n");
+        return;
+    }
+
+    if (layer_size < 1)
+    {
+        fprintf(stderr, "ERROR: Output Parser - Layer size is less than 1, cannot fix header\n");
+        return;
+    }
+
+    // TODO - Implement output_fix_dos_header()
+    fprintf(stderr, "WARNING: Output Parser - DOS header fixer not implemented.\n");
+}

--- a/src/output_parser.c
+++ b/src/output_parser.c
@@ -139,7 +139,7 @@ void output_fix_dos_header(void *layer, ssize_t layer_size, uint64_t entry)
 
     for (unsigned i = 0; i < (layer_pe.file_header->NumberOfSections); i++)
     {
-        if ((unsigned long) &(layer_pe.sect_header[i]) > (unsigned long) layer_size)
+        if ((unsigned long) & (layer_pe.sect_header[i]) > (unsigned long) layer_size)
         {
             fprintf(stderr, "WARNING: Output Parser - Bad pointer in section header %u\n", i);
             break;

--- a/src/output_parser.c
+++ b/src/output_parser.c
@@ -137,7 +137,8 @@ void output_fix_dos_header(void *layer, ssize_t layer_size, uint64_t entry)
     // Fix sections
     layer_pe.file_header->NumberOfSections = base_image_pe.file_header->NumberOfSections;
 
-    for (unsigned i = 0; i < (layer_pe.file_header->NumberOfSections); i++)
+    unsigned i;
+    for (i = 0; i < (layer_pe.file_header->NumberOfSections); i++)
     {
         if ((unsigned long) & (layer_pe.sect_header[i]) > (unsigned long) layer_size)
         {

--- a/src/process/process.c
+++ b/src/process/process.c
@@ -39,6 +39,7 @@ bool process_vmi_init_linux(char *rekall_filepath)
     vmi_current_pid = vmi_current_pid_linux;
     vmi_current_name = vmi_current_name_linux;
     vmi_current_parent_pid = vmi_current_parent_pid_linux;
+    vmi_current_find_segment = vmi_current_find_segment_linux;
 
     process_vmi_ready = 1;
     return 1;
@@ -56,6 +57,7 @@ bool process_vmi_init_windows(char *rekall_filepath)
     vmi_current_pid = vmi_current_pid_windows;
     vmi_current_name = vmi_current_name_windows;
     vmi_current_parent_pid = vmi_current_parent_pid_windows;
+    vmi_current_find_segment = vmi_current_find_segment_windows;
 
     process_vmi_ready = 1;
     return 1;

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -29,7 +29,6 @@
 
 addr_t vmi_current_thread_windows(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     addr_t thread;
     addr_t prcb;
     addr_t currentthread;
@@ -49,25 +48,67 @@ addr_t vmi_current_thread_windows(vmi_instance_t vmi, vmi_event_t *event)
     return thread;
 }
 
+addr_t windows_find_eprocess_pgd(vmi_instance_t vmi, addr_t pgd)
+{
+    addr_t list_head, next_process, pdbase;
+    addr_t pdbase_offset = process_vmi_windows_rekall.kprocess_pdbase;
+    addr_t tasks_offset = process_vmi_windows_rekall.eprocess_tasks;
+
+    if (vmi_read_addr_ksym(vmi, "PsInitialSystemProcess", &list_head) != VMI_SUCCESS)
+        return 0;
+
+    if (vmi_read_addr_va(vmi, list_head + tasks_offset, 0, &next_process) != VMI_SUCCESS)
+        return 0;
+
+    if (vmi_read_addr_va(vmi, list_head + pdbase_offset, 0, &pdbase) != VMI_SUCCESS)
+        return 0;
+
+    if (pdbase == pgd)
+        return 0; // TODO - Correctly return a pointer to PsInitialSystemProcess
+
+    list_head = next_process;
+
+    while (1)
+    {
+        addr_t tmp_next;
+
+        if (vmi_read_addr_va(vmi, next_process, 0, &tmp_next) != VMI_SUCCESS)
+            return 0;
+
+        if (list_head == tmp_next)
+            return 0;
+
+        if (vmi_read_addr_va(vmi, next_process + pdbase_offset - tasks_offset, 0, &pdbase) != VMI_SUCCESS)
+            return 0;
+
+        if (pdbase == pgd)
+            return next_process - tasks_offset;
+
+        next_process = tmp_next;
+    }
+
+    return 0;
+}
+
 addr_t vmi_current_process_windows(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     addr_t process;
     addr_t thread = vmi_current_thread_windows(vmi, event);
 
+    // If we can't find the current process the fast way, fall back to the slower
+    // but more reliable windows_find_eprocess_pgd.
     if (!thread)
-        return 0;
+        return windows_find_eprocess_pgd(vmi, event->x86_regs->cr3);
 
     addr_t kthread = thread + process_vmi_windows_rekall.kthread_process;
     if (vmi_read_addr_va(vmi, kthread, 0, &process) != VMI_SUCCESS)
-        return 0;
+        return windows_find_eprocess_pgd(vmi, event->x86_regs->cr3);
 
     return process;
 }
 
 vmi_pid_t vmi_current_pid_windows(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     if (!process_vmi_ready)
     {
         fprintf(stderr, "ERROR: Windows Process VMI - Not initialized\n");
@@ -89,7 +130,6 @@ vmi_pid_t vmi_current_pid_windows(vmi_instance_t vmi, vmi_event_t *event)
 
 char *vmi_current_name_windows(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     if (!process_vmi_ready)
     {
         fprintf(stderr, "ERROR: Windows Process VMI - Not initialized\n");
@@ -108,7 +148,6 @@ char *vmi_current_name_windows(vmi_instance_t vmi, vmi_event_t *event)
 
 vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     if (!process_vmi_ready)
     {
         fprintf(stderr, "ERROR: Windows Process VMI - Not initialized\n");
@@ -130,12 +169,89 @@ vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event)
 
 mem_seg_t vmi_current_find_segment_windows(vmi_instance_t vmi, vmi_event_t *event, addr_t addr)
 {
-    // TODO - implement vmi_current_find_segment_windows
-    fprintf(stderr, "WARNING: Windows Process VMI - vmi_current_find_segment_windows not implemented.\n");
     mem_seg_t mem_seg =
     {
         mem_seg.base_va = 0,
         mem_seg.size = 0,
     };
+
+    if (!process_vmi_ready)
+    {
+        fprintf(stderr, "ERROR: Windows Process VMI - Not initialized\n");
+        return mem_seg;
+    }
+
+    addr_t process = vmi_current_process_windows(vmi, event);
+
+    if (!process)
+    {
+        fprintf(stderr, "WARNING: Windows Process VMI - Could not find current process\n");
+        return mem_seg;
+    }
+
+    // Windows tracks memory mappings using Virtual Address Descriptors (VADs), which serves the
+    // same purpose of Linux's virtual memory areas (VMAs). VADs are organized as a balanced binary
+    // tree starting with the root VAD.
+    //
+    // For more information, see: http://lilxam.tuxfamily.org/blog/?p=326&lang=en
+    addr_t curr_vad;
+    addr_t eprocess_vadroot = process + process_vmi_windows_rekall.eprocess_vadroot;
+
+    if (vmi_read_addr_va(vmi, eprocess_vadroot, 0, &curr_vad) != VMI_SUCCESS)
+    {
+        fprintf(stderr, "WARNING: Windows Process VMI - Could not find root VAD\n");
+        return mem_seg;
+    }
+    // root VAD is an _EX_FAST_REF, so the 3 least significant bits are a reference counter.
+    curr_vad &= 0xFFFFFFFFFFFFFFF8;
+
+    while (1)
+    {
+        // Get the starting virtual address for this VAD.
+        addr_t startingvpn;
+        addr_t mmvad_startingvpn = curr_vad + process_vmi_windows_rekall.mmvad_startingvpn;
+        if (vmi_read_addr_va(vmi, mmvad_startingvpn, 0, &startingvpn) != VMI_SUCCESS)
+            return mem_seg;
+        startingvpn <<= 12; // virtual page number << 12 (4KB per page) = virtual address
+
+        // If the address we're trying to find is less than startingvpn, we need to check the left
+        // child of the current VAD.
+        if (addr < startingvpn)
+        {
+            addr_t mmvad_leftchild = curr_vad + process_vmi_windows_rekall.mmvad_leftchild;
+            if (vmi_read_addr_va(vmi, mmvad_leftchild, 0, &curr_vad) != VMI_SUCCESS)
+                return mem_seg;
+
+            if (!curr_vad)
+                return mem_seg;
+
+            continue;
+        }
+
+        // Get the ending virtual address for this VAD.
+        addr_t endingvpn;
+        addr_t mmvad_endingvpn = curr_vad + process_vmi_windows_rekall.mmvad_endingvpn;
+        if (vmi_read_addr_va(vmi, mmvad_endingvpn, 0, &endingvpn) != VMI_SUCCESS)
+            return mem_seg;
+        endingvpn <<= 12;
+
+        // If the address we're looking for is less than or equal to endingvpn, we've found our VAD.
+        // (We've already confirmed that the address is greater than or equal to startingvpn).
+        if (addr < endingvpn)
+        {
+            mem_seg.base_va = startingvpn;
+            mem_seg.size = endingvpn - startingvpn;
+            return mem_seg;
+        }
+
+        // The address we're looking for is greater than endingvpn, we need to check the right child.
+        addr_t mmvad_rightchild = curr_vad + process_vmi_windows_rekall.mmvad_rightchild;
+        if (vmi_read_addr_va(vmi, mmvad_rightchild, 0, &curr_vad) != VMI_SUCCESS)
+            return mem_seg;
+
+        if (!curr_vad)
+            return mem_seg;
+    }
+
     return mem_seg;
 }

--- a/src/process/windows.c
+++ b/src/process/windows.c
@@ -127,3 +127,15 @@ vmi_pid_t vmi_current_parent_pid_windows(vmi_instance_t vmi, vmi_event_t *event)
 
     return parent_pid;
 }
+
+mem_seg_t vmi_current_find_segment_windows(vmi_instance_t vmi, vmi_event_t *event, addr_t addr)
+{
+    // TODO - implement vmi_current_find_segment_windows
+    fprintf(stderr, "WARNING: Windows Process VMI - vmi_current_find_segment_windows not implemented.\n");
+    mem_seg_t mem_seg =
+    {
+        mem_seg.base_va = 0,
+        mem_seg.size = 0,
+    };
+    return mem_seg;
+}

--- a/src/rekall_parser.c
+++ b/src/rekall_parser.c
@@ -367,6 +367,33 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file)
     json_reader_end_member(reader);
     json_reader_end_member(reader);
 
+    // kprocess_pdbase
+    if (!json_reader_read_member(reader, "_KPROCESS"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _KPROCESS\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 1))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _KPROCESS[1]\n");
+        return 0;
+    }
+    if (!json_reader_read_member(reader, "DirectoryTableBase"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _KPROCESS[1]['DirectoryTableBase']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _KPROCESS[1]['DirectoryTableBase'][0]\n");
+        return 0;
+    }
+    rekall->kprocess_pdbase = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
     // eprocess_pname
     if (!json_reader_read_member(reader, "_EPROCESS"))
     {
@@ -419,6 +446,105 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file)
         return 0;
     }
     rekall->eprocess_parent_pid = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // eprocess_tasks
+    if (!json_reader_read_member(reader, "ActiveProcessLinks"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['ActiveProcessLinks']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['ActiveProcessLinks'][0]\n");
+        return 0;
+    }
+    rekall->eprocess_tasks = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // eprocess_vadroot
+    if (!json_reader_read_member(reader, "VadRoot"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['VadRoot']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _EPROCESS[1]['VadRoot'][0]\n");
+        return 0;
+    }
+    rekall->eprocess_vadroot = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // mmvad_leftchild
+    if (!json_reader_read_member(reader, "_MMVAD"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 1))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]\n");
+        return 0;
+    }
+    if (!json_reader_read_member(reader, "LeftChild"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['LeftChild']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['LeftChild'][0]\n");
+        return 0;
+    }
+    rekall->mmvad_leftchild = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    if (!json_reader_read_member(reader, "RightChild"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['RightChild']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['RightChild'][0]\n");
+        return 0;
+    }
+    rekall->mmvad_rightchild = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    if (!json_reader_read_member(reader, "StartingVpn"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['StartingVpn']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['StartingVpn'][0]\n");
+        return 0;
+    }
+    rekall->mmvad_startingvpn = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    if (!json_reader_read_member(reader, "EndingVpn"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['EndingVpn']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate _MMVAD[1]['EndingVpn'][0]\n");
+        return 0;
+    }
+    rekall->mmvad_endingvpn = json_reader_get_int_value(reader);
 
     g_object_unref(reader);
     g_object_unref(parser);

--- a/src/rekall_parser.c
+++ b/src/rekall_parser.c
@@ -132,6 +132,135 @@ bool parse_rekall_linux(linux_rekall_t *rekall, char *json_file)
         return 0;
     }
     rekall->task_struct_parent = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // task_struct->mm
+    if (!json_reader_read_member(reader, "mm"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['mm']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['mm'][0]\n");
+        return 0;
+    }
+    rekall->task_struct_mm = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // task_struct->tasks
+    if (!json_reader_read_member(reader, "tasks"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['tasks']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate task_struct[1]['tasks'][0]\n");
+        return 0;
+    }
+    rekall->task_struct_tasks = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // mm_struct->mmap
+    if (!json_reader_read_member(reader, "mm_struct"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 1))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct[1]\n");
+        return 0;
+    }
+    if (!json_reader_read_member(reader, "mmap"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct[1]['mmap']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct[1]['mmap'][0]\n");
+        return 0;
+    }
+    rekall->mm_struct_mmap = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // mm_struct->pgd
+    if (!json_reader_read_member(reader, "pgd"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct[1]['pgd']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate mm_struct[1]['pgd'][0]\n");
+        return 0;
+    }
+    rekall->mm_struct_pgd = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // vm_area_struct->vm_start
+    if (!json_reader_read_member(reader, "vm_area_struct"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 1))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]\n");
+        return 0;
+    }
+    if (!json_reader_read_member(reader, "vm_start"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_start']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_start'][0]\n");
+        return 0;
+    }
+    rekall->vm_area_struct_vm_start = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // vm_area_struct->vm_end
+    if (!json_reader_read_member(reader, "vm_end"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_end']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_end'][0]\n");
+        return 0;
+    }
+    rekall->vm_area_struct_vm_end = json_reader_get_int_value(reader);
+    json_reader_end_member(reader);
+    json_reader_end_member(reader);
+
+    // vm_area_struct->vm_next
+    if (!json_reader_read_member(reader, "vm_next"))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_next']\n");
+        return 0;
+    }
+    if (!json_reader_read_element(reader, 0))
+    {
+        fprintf(stderr, "ERROR: Rekall Parser - Failed to locate vm_area_struct[1]['vm_next'][0]\n");
+        return 0;
+    }
+    rekall->vm_area_struct_vm_next = json_reader_get_int_value(reader);
 
     g_object_unref(reader);
     g_object_unref(parser);

--- a/tools/cr3_tracker.c
+++ b/tools/cr3_tracker.c
@@ -42,7 +42,6 @@ static void close_handler(int sig)
 
 event_response_t monitor_cr3(vmi_instance_t vmi, vmi_event_t *event)
 {
-
     vmi_pid_t pid = vmi_current_pid(vmi, event);
     vmi_pid_t parent_pid = vmi_current_parent_pid(vmi, event);
     char *name = vmi_current_name(vmi, event);
@@ -59,7 +58,6 @@ event_response_t monitor_cr3(vmi_instance_t vmi, vmi_event_t *event)
  */
 int main(int argc, char *argv[])
 {
-
     domain_name = NULL;
     char *rekall = NULL;
 

--- a/tools/rekall_linux.c
+++ b/tools/rekall_linux.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
     if (!parse_rekall_linux(&rekall, argv[1]))
     {
         printf("Failed to parse rekall file\n");
+        return EXIT_FAILURE;
     }
     else
     {

--- a/tools/rekall_linux.c
+++ b/tools/rekall_linux.c
@@ -27,7 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-
     if (argc < 2)
     {
         printf("%s <json_file>\n", argv[0]);
@@ -41,9 +40,12 @@ int main(int argc, char *argv[])
     }
     else
     {
-        printf("current_thread = %ld, comm = %ld, pid = %ld parent = %ld\n",
+        printf("current_thread = %ld, comm = %ld, pid = %ld parent = %ld, mm = %ld tasks = %ld\n",
                rekall.current_task, rekall.task_struct_comm, rekall.task_struct_pid,
-               rekall.task_struct_parent);
+               rekall.task_struct_parent, rekall.task_struct_mm, rekall.task_struct_tasks);
+        printf("mmap = %ld, vm_start = %ld, vm_end = %ld, vm_next = %ld pgd = %ld\n",
+               rekall.mm_struct_mmap, rekall.vm_area_struct_vm_start,
+               rekall.vm_area_struct_vm_end, rekall.vm_area_struct_vm_next, rekall.mm_struct_pgd);
     }
 
     return EXIT_SUCCESS;

--- a/tools/rekall_windows.c
+++ b/tools/rekall_windows.c
@@ -38,12 +38,17 @@ int main(int argc, char *argv[])
     if (!parse_rekall_windows(&rekall, argv[1]))
     {
         printf("Failed to parse rekall file\n");
+        return EXIT_FAILURE;
     }
     else
     {
-        printf("kprc_prcb = %ld, kpcr_currentthread = %ld, kthread_process = %ld, eprocess_pname = %ld, eprocess_pid = %ld eprocess_parent_pid = %ld\n",
-               rekall.kpcr_prcb, rekall.kprcb_currentthread, rekall.kthread_process, rekall.eprocess_pname,
-               rekall.eprocess_pid, rekall.eprocess_parent_pid);
+        printf("kprocess_pdbase = %ld\n", rekall.kprocess_pdbase);
+        printf("kprc_prcb = %ld, kpcr_currentthread = %ld, kthread_process = %ld\n",
+               rekall.kpcr_prcb, rekall.kprcb_currentthread, rekall.kthread_process);
+        printf("eprocess_pname = %ld eprocess_pid = %ld eprocess_parent_pid = %ld eprocess_vadroot = %ld\n",
+               rekall.eprocess_pname, rekall.eprocess_pid, rekall.eprocess_parent_pid, rekall.eprocess_vadroot);
+        printf("mmvad_leftchild = %ld mmvad_rightchild = %ld mmvad_startingvpn = %ld mmvad_endingvpn = %ld\n",
+               rekall.mmvad_leftchild, rekall.mmvad_rightchild, rekall.mmvad_startingvpn, rekall.mmvad_endingvpn);
     }
 
     return EXIT_SUCCESS;

--- a/tools/vmi_table_walk.c
+++ b/tools/vmi_table_walk.c
@@ -107,7 +107,7 @@ void walk_pml4(vmi_instance_t vmi, int pid)
     addr_t entry_addr;
     uint64_t entry_val;
 
-    dtb = vmi_pid_to_dtb(vmi, (vmi_pid_t) pid);
+    vmi_pid_to_dtb(vmi, (vmi_pid_t) pid, &dtb);
 
     // PML4
     pml4 = PAGING_INTEL_64_GET_PML4_PADDR(dtb);


### PR DESCRIPTION
Similar to Ether, this unpacker now has an option to provide a base image and it will be used to "fix" a dumped layer if that layer contains a Windows PE header.