### PR TITLE
Tweak output filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Optional arguments:
 
 Every time the target process writes data to a page and then executes it, the memory
 segment that page belongs to will be extracted as a layer. Layers are written to the
-provided output directory in the form `<pid>-<layer>-<rip>.bin` where `<layer>`
-starts at 0 and increments with each newly extracted layer and `<rip>` is the value
-of the program counter when the layer is first executed. This value can also be
-interpreted as the virtual address the layer starts at.
+provided output directory in the form `<pid>-<layer>-<base_addr>-<rip>.bin` where
+`<layer>` starts at 0 and increments with each newly extracted layer, `<base_addr>`
+is the base virtual address of the extracted memory segment, and `<rip>` is the
+value of the program counter when the layer is executed.


### PR DESCRIPTION
Saved layers now contain the base virtual address of the extracted layers because this may not equal the RIP.