### PR TITLE
skip dead processes and use volatility for process dumping

### DIFF
--- a/include/monitor.h
+++ b/include/monitor.h
@@ -133,9 +133,13 @@ typedef struct
     page_cat_t cat;
 } trapped_page_t;
 
+#ifdef TRACE_TRAPS
 #define trace_trap(addr, trap, mesg) fprintf(stderr, \
         "%s:trace_trap paddr=%p pid=%d cat=%s mesg=%s\n", \
         __FUNCTION__, (gpointer)addr, trap->pid, cat2str(trap->cat), mesg)
+#else
+#define trace_trap(addr, trap, mesg)
+#endif
 
 typedef struct
 {

--- a/include/output.h
+++ b/include/output.h
@@ -44,8 +44,8 @@ typedef void (*traverse_func)(vmi_instance_t, addr_t, void *);
  * @param cat The type of page that the event triggered on.
  */
 void process_layer(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
-
 void vad_dump_process(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
+void volatility_vaddump(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
 
 /**
  * Iterates over a VAD tree

--- a/include/rekall_parser.h
+++ b/include/rekall_parser.h
@@ -38,6 +38,7 @@ typedef struct
     gint64 eprocess_pid;
     gint64 eprocess_parent_pid;
     gint64 eprocess_tasks;
+    gint64 eprocess_objecttable;
     gint64 eprocess_vadroot;
     gint64 mmvad_leftchild;
     gint64 mmvad_rightchild;

--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,8 @@ event_response_t monitor_pid(vmi_instance_t vmi, vmi_event_t *event)
     {
         fprintf(stderr, "*********** FOUND PARENT: PID %d *****\n", pid);
         // monitor_add_page_table(vmi, pid, process_layer, tracking_flags, 0);
-        monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        // monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        monitor_add_page_table(vmi, pid, volatility_vaddump, tracking_flags, 0);
         monitor_remove_cr3(monitor_pid);
     }
 
@@ -93,7 +94,8 @@ event_response_t monitor_name(vmi_instance_t vmi, vmi_event_t *event)
         process_pid = pid;
         fprintf(stderr, "*********** FOUND PARENT: PID %d *****\n", pid);
         // monitor_add_page_table(vmi, pid, process_layer, tracking_flags, 0);
-        monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        // monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        monitor_add_page_table(vmi, pid, volatility_vaddump, tracking_flags, 0);
         monitor_remove_cr3(monitor_name);
     }
     free(name);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -217,8 +217,10 @@ void monitor_trap_vma(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, mem
         }
         if (!g_hash_table_contains(exec_map, (gpointer)event->mem_event.gfn))
         {
+#ifdef TRACE_TRAPS
             fprintf(stderr, "monitor_trap_vma: %d, base_va=0x%lx, paddr=0x%lx\n",
                     pid, vma.base_va, PADDR_SHIFT(event->mem_event.gfn));
+#endif
             g_hash_table_add(exec_map, (gpointer)event->mem_event.gfn);
             vmi_set_mem_event(vmi, event->mem_event.gfn, VMI_MEMACCESS_X, 0);
         }

--- a/src/output.c
+++ b/src/output.c
@@ -158,7 +158,7 @@ void handle_node(vmi_instance_t vmi, addr_t node, void *data)
     dump->segments[dump->segment_count]->base_va = base_va;
     dump->segments[dump->segment_count]->size = size;
     dump->segments[dump->segment_count]->va_size = size;
-    dump->segments[dump->segment_count]->buf = malloc(size);
+    dump->segments[dump->segment_count]->buf = calloc(1, size);
     size_t read_size = 0;
     vmi_read_va(
         vmi,

--- a/src/output.c
+++ b/src/output.c
@@ -147,6 +147,13 @@ void handle_node(vmi_instance_t vmi, addr_t node, void *data)
     if (!start || !end) return;
     base_va = start;
     size = end - start;
+    // this is some weird address padding that results in huge sections of memory
+    // that probably dont contain anything useful.
+    if (end > 0x7ff00000000)
+    {
+        //printf("%s: start:%#016lx end:%#016lx\n", __func__, start, end);
+        return;
+    }
     dump->segments[dump->segment_count] = malloc(sizeof(vad_seg_t));
     dump->segments[dump->segment_count]->base_va = base_va;
     dump->segments[dump->segment_count]->size = size;

--- a/src/rekall_parser.c
+++ b/src/rekall_parser.c
@@ -123,6 +123,7 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file)
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['UniqueProcessId'][0]", root, &rekall->eprocess_pid);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['InheritedFromUniqueProcessId'][0]", root, &rekall->eprocess_parent_pid);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['ActiveProcessLinks'][0]", root, &rekall->eprocess_tasks);
+    set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['ObjectTable'][0]", root, &rekall->eprocess_objecttable);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['VadRoot'][0]", root, &rekall->eprocess_vadroot);
     set_rekall_val("$['$STRUCTS']['_MMVAD'][1]['LeftChild'][0]", root, &rekall->mmvad_leftchild);
     set_rekall_val("$['$STRUCTS']['_MMVAD'][1]['RightChild'][0]", root, &rekall->mmvad_rightchild);

--- a/test/unit.c
+++ b/test/unit.c
@@ -77,6 +77,7 @@ void test_windows_rekall()
     CU_ASSERT(rekall.eprocess_pid == 384);
     CU_ASSERT(rekall.eprocess_parent_pid == 656);
     CU_ASSERT(rekall.eprocess_vadroot == 1096);
+    CU_ASSERT(rekall.eprocess_objecttable == 512);
     CU_ASSERT(rekall.mmvad_leftchild == 8);
     CU_ASSERT(rekall.mmvad_rightchild == 16);
     CU_ASSERT(rekall.mmvad_startingvpn == 24);


### PR DESCRIPTION
two things to look into:
1) when a parent process opens a child, then the child exits, but the parent still has the handle open, Windows does not yet remove the process from the process list. It does set a few data structures as NULL. so, we detect this and skip dead processes still in the process list.

2) major strategy change: stop doing our own process dumping techniques and outsource that work to Volatility. The change does require that you manually add the Xen address space plugin from the LibVMI Python bindings into Volatility's plugins path.

pay close attention to output.c to see if I did anything stupid with calling the external process. I was not going for a strict, clean environment/path/etc. for calling volatility. I also haven't ACTUALLY tested it yet. so, hold off on merging this.

also also, since we are shelling out synchronously, on purpose, we probably don't need the worker thread that was used for dumping. But, it should remain for now just in case we have to revert or have other needs.