### PR TITLE
Offload process memory dumping to volatility.

### DIFF
--- a/include/monitor.h
+++ b/include/monitor.h
@@ -133,9 +133,13 @@ typedef struct
     page_cat_t cat;
 } trapped_page_t;
 
+#ifdef TRACE_TRAPS
 #define trace_trap(addr, trap, mesg) fprintf(stderr, \
         "%s:trace_trap paddr=%p pid=%d cat=%s mesg=%s\n", \
         __FUNCTION__, (gpointer)addr, trap->pid, cat2str(trap->cat), mesg)
+#else
+#define trace_trap(addr, trap, mesg)
+#endif
 
 typedef struct
 {

--- a/include/output.h
+++ b/include/output.h
@@ -44,8 +44,8 @@ typedef void (*traverse_func)(vmi_instance_t, addr_t, void *);
  * @param cat The type of page that the event triggered on.
  */
 void process_layer(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
-
 void vad_dump_process(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
+void volatility_vaddump(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat);
 
 /**
  * Iterates over a VAD tree

--- a/include/rekall_parser.h
+++ b/include/rekall_parser.h
@@ -38,6 +38,7 @@ typedef struct
     gint64 eprocess_pid;
     gint64 eprocess_parent_pid;
     gint64 eprocess_tasks;
+    gint64 eprocess_objecttable;
     gint64 eprocess_vadroot;
     gint64 mmvad_leftchild;
     gint64 mmvad_rightchild;

--- a/src/main.c
+++ b/src/main.c
@@ -155,7 +155,8 @@ int main(int argc, char *argv[])
     }
 
     // santity checks for volatility
-    if (system("which volatility")) {
+    if (system("which volatility"))
+    {
         fprintf(stderr, "ERROR: Unpack - volatility not found in path.\n");
         return EXIT_FAILURE;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,8 @@ event_response_t monitor_pid(vmi_instance_t vmi, vmi_event_t *event)
     {
         fprintf(stderr, "*********** FOUND PARENT: PID %d *****\n", pid);
         // monitor_add_page_table(vmi, pid, process_layer, tracking_flags, 0);
-        monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        // monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        monitor_add_page_table(vmi, pid, volatility_vaddump, tracking_flags, 0);
         monitor_remove_cr3(monitor_pid);
     }
 
@@ -93,7 +94,8 @@ event_response_t monitor_name(vmi_instance_t vmi, vmi_event_t *event)
         process_pid = pid;
         fprintf(stderr, "*********** FOUND PARENT: PID %d *****\n", pid);
         // monitor_add_page_table(vmi, pid, process_layer, tracking_flags, 0);
-        monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        // monitor_add_page_table(vmi, pid, vad_dump_process, tracking_flags, 0);
+        monitor_add_page_table(vmi, pid, volatility_vaddump, tracking_flags, 0);
         monitor_remove_cr3(monitor_name);
     }
     free(name);

--- a/src/main.c
+++ b/src/main.c
@@ -154,6 +154,12 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    // santity checks for volatility
+    if (system("which volatility")) {
+        fprintf(stderr, "ERROR: Unpack - volatility not found in path.\n");
+        return EXIT_FAILURE;
+    }
+
     // setup signal mask for worker threads, who will not be handling any signals
     sigemptyset(&my_sigs);
     sigaddset(&my_sigs, SIGTERM);

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@
 /* Global variables */
 char *domain_name = NULL;
 char *process_name = NULL;
+char *vol_profile = NULL;
 char *output_dir = NULL;
 char *rekall = NULL;
 vmi_pid_t process_pid = 0;
@@ -57,6 +58,7 @@ void usage(char *name)
     printf("Required arguments:\n");
     printf("    -d <domain_name>         Name of VM to unpack from.\n");
     printf("    -r <rekall_file>         Path to rekall file.\n");
+    printf("    -v <vol_profile>         Volatility profile to use.\n");
     printf("    -o <output_dir>          Directory to dump layers into.\n");
     printf("\n");
     printf("One of the following must be provided:\n");
@@ -111,7 +113,7 @@ int main(int argc, char *argv[])
     int c;
 
     // Parse arguments
-    while ((c = getopt(argc, argv, "d:r:o:p:n:fl")) != -1)
+    while ((c = getopt(argc, argv, "d:r:v:o:p:n:fl")) != -1)
     {
         switch (c)
         {
@@ -120,6 +122,9 @@ int main(int argc, char *argv[])
                 break;
             case 'r':
                 rekall = optarg;
+                break;
+            case 'v':
+                vol_profile = optarg;
                 break;
             case 'o':
                 output_dir = optarg;
@@ -142,7 +147,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (domain_name == NULL || rekall == NULL || output_dir == NULL ||
+    if (!domain_name || !rekall || !vol_profile || !output_dir ||
         (process_pid == 0 && process_name == NULL))
     {
         usage(argv[0]);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -217,8 +217,10 @@ void monitor_trap_vma(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, mem
         }
         if (!g_hash_table_contains(exec_map, (gpointer)event->mem_event.gfn))
         {
+#ifdef TRACE_TRAPS
             fprintf(stderr, "monitor_trap_vma: %d, base_va=0x%lx, paddr=0x%lx\n",
                     pid, vma.base_va, PADDR_SHIFT(event->mem_event.gfn));
+#endif
             g_hash_table_add(exec_map, (gpointer)event->mem_event.gfn);
             vmi_set_mem_event(vmi, event->mem_event.gfn, VMI_MEMACCESS_X, 0);
         }

--- a/src/output.c
+++ b/src/output.c
@@ -33,7 +33,9 @@
 #include <paging/intel_64.h>
 #include <vmi/process.h>
 
+/* defined in main.c */
 extern char *domain_name;
+extern char *vol_profile;
 extern char *output_dir;
 
 void process_layer(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat)
@@ -273,13 +275,13 @@ int capture_cmd(const char *cmd, const char *fn)
 
 void volatility_vaddump(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat)
 {
-//  volatility -l vmi://win7-borg vaddump -D ~/borg-out/ -p 2448
-//  volatility -l vmi://win7-borg vadinfo --output=json -p 2448 --output-file=calc_upx.exe.vadinfo.json
+//  volatility -l vmi://win7-borg --profile=Win7SP0x64 vaddump -D ~/borg-out/ -p 2448
+//  volatility -l vmi://win7-borg --profile=Win7SP0x64 vadinfo --output=json -p 2448 --output-file=calc_upx.exe.vadinfo.json
 
   // vmi_pid_t is int32_t which can be int or long
   // so, for pid, we use %ld and cast to long
-  const char *vaddump_cmd = "%svolatility -l vmi://%s vaddump -D %s 2>&1 -p %ld";
-  const char *vadinfo_cmd = "%svolatility -l vmi://%s vadinfo --output=json --output-file=%s 2>&1 -p %ld";
+  const char *vaddump_cmd = "%svolatility -l vmi://%s --profile=%s vaddump -D %s 2>&1 -p %ld";
+  const char *vadinfo_cmd = "%svolatility -l vmi://%s --profile=%s  vadinfo --output=json --output-file=%s 2>&1 -p %ld";
   const size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
   char *cmd = NULL;
   char *cmd_prefix = "";
@@ -292,13 +294,13 @@ void volatility_vaddump(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, p
   filepath = malloc(PATH_MAX);
 
   // vaddump
-  snprintf(cmd, cmd_max-1, vaddump_cmd, cmd_prefix, domain_name, output_dir, (long)pid);
+  snprintf(cmd, cmd_max-1, vaddump_cmd, cmd_prefix, domain_name, vol_profile, output_dir, (long)pid);
   snprintf(filepath, PATH_MAX - 1, "%s/vaddump_output.%04d.%ld", output_dir, dump_count, (long)pid);
   capture_cmd(cmd, filepath);
 
   // vadinfo
   snprintf(filepath, PATH_MAX - 1, "%s/vadinfo.%04d.%ld.json", output_dir, dump_count, (long)pid);
-  snprintf(cmd, cmd_max-1, vadinfo_cmd, cmd_prefix, domain_name, filepath, (long)pid);
+  snprintf(cmd, cmd_max-1, vadinfo_cmd, cmd_prefix, domain_name, vol_profile, filepath, (long)pid);
   snprintf(filepath, PATH_MAX - 1, "%s/vadinfo_output.%04d.%ld", output_dir, dump_count, (long)pid);
   capture_cmd(cmd, filepath);
 

--- a/src/output.c
+++ b/src/output.c
@@ -158,7 +158,7 @@ void handle_node(vmi_instance_t vmi, addr_t node, void *data)
     dump->segments[dump->segment_count]->base_va = base_va;
     dump->segments[dump->segment_count]->size = size;
     dump->segments[dump->segment_count]->va_size = size;
-    dump->segments[dump->segment_count]->buf = malloc(size);
+    dump->segments[dump->segment_count]->buf = calloc(1, size);
     size_t read_size = 0;
     vmi_read_va(
         vmi,

--- a/src/output.c
+++ b/src/output.c
@@ -147,6 +147,13 @@ void handle_node(vmi_instance_t vmi, addr_t node, void *data)
     if (!start || !end) return;
     base_va = start;
     size = end - start;
+    // this is some weird address padding that results in huge sections of memory
+    // that probably dont contain anything useful.
+    if (end > 0x7ff00000000)
+    {
+        //printf("%s: start:%#016lx end:%#016lx\n", __func__, start, end);
+        return;
+    }
     dump->segments[dump->segment_count] = malloc(sizeof(vad_seg_t));
     dump->segments[dump->segment_count]->base_va = base_va;
     dump->segments[dump->segment_count]->size = size;

--- a/src/output.c
+++ b/src/output.c
@@ -230,83 +230,84 @@ void vad_iterator(vmi_instance_t vmi, addr_t node, traverse_func func, void *dat
 
 int capture_cmd(const char *cmd, const char *fn)
 {
-  FILE *pipe = NULL;
-  FILE *out_f = NULL;
-  char *out_buf = NULL;
-  size_t out_size;
-  const size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
+    FILE *pipe = NULL;
+    FILE *out_f = NULL;
+    char *out_buf = NULL;
+    size_t out_size;
+    const size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
 
-  // fork&exec cmd
-  // NOTE: popen does not capture stderr. cmd should have "2>&1" if you want stderr
-  pipe = popen(cmd, "r");
-  if (pipe == NULL)
-  {
-    fprintf(stderr, "%s: failed to run cmd {%s}\n", __func__, cmd);
-    return -1;
-  }
+    // fork&exec cmd
+    // NOTE: popen does not capture stderr. cmd should have "2>&1" if you want stderr
+    pipe = popen(cmd, "r");
+    if (pipe == NULL)
+    {
+        fprintf(stderr, "%s: failed to run cmd {%s}\n", __func__, cmd);
+        return -1;
+    }
 
-  // capture cmd output and write to fn
-  out_f = fopen(fn, "w");
-  if (!out_f)
-  {
-    fprintf(stderr, "%s: error: failed to open {%s} for writing\n", __func__, fn);
-    pclose(pipe);
-    return -1;
-  }
-  out_buf = malloc(PAGE_SIZE);
-  if (!out_buf)
-  {
-    fprintf(stderr, "%s: error: failed to allocate buffer\n", __func__);
+    // capture cmd output and write to fn
+    out_f = fopen(fn, "w");
+    if (!out_f)
+    {
+        fprintf(stderr, "%s: error: failed to open {%s} for writing\n", __func__, fn);
+        pclose(pipe);
+        return -1;
+    }
+    out_buf = malloc(PAGE_SIZE);
+    if (!out_buf)
+    {
+        fprintf(stderr, "%s: error: failed to allocate buffer\n", __func__);
+        fclose(out_f);
+        pclose(pipe);
+        return -1;
+    }
+
+    while (1)
+    {
+        out_size = fread(out_buf, 1, PAGE_SIZE, pipe);
+        if (!out_size)
+            break;
+        if (fwrite(out_buf, 1, out_size, out_f) != out_size)
+            fprintf(stderr, "%s: warning: short write to {%s}\n", __func__, fn);
+    }
+
+    free(out_buf);
     fclose(out_f);
-    pclose(pipe);
-    return -1;
-  }
-
-  while (1) {
-    out_size = fread(out_buf, 1, PAGE_SIZE, pipe);
-    if (!out_size)
-      break;
-    if (fwrite(out_buf, 1, out_size, out_f) != out_size)
-      fprintf(stderr, "%s: warning: short write to {%s}\n", __func__, fn);
-  }
-
-  free(out_buf);
-  fclose(out_f);
-  return 0;
+    return 0;
 }
 
 void volatility_vaddump(vmi_instance_t vmi, vmi_event_t *event, vmi_pid_t pid, page_cat_t page_cat)
 {
-//  volatility -l vmi://win7-borg --profile=Win7SP0x64 vaddump -D ~/borg-out/ -p 2448
-//  volatility -l vmi://win7-borg --profile=Win7SP0x64 vadinfo --output=json -p 2448 --output-file=calc_upx.exe.vadinfo.json
+    //  volatility -l vmi://win7-borg --profile=Win7SP0x64 vaddump -D ~/borg-out/ -p 2448
+    //  volatility -l vmi://win7-borg --profile=Win7SP0x64 vadinfo --output=json -p 2448 --output-file=calc_upx.exe.vadinfo.json
 
-  // vmi_pid_t is int32_t which can be int or long
-  // so, for pid, we use %ld and cast to long
-  const char *vaddump_cmd = "%svolatility -l vmi://%s --profile=%s vaddump -D %s 2>&1 -p %ld";
-  const char *vadinfo_cmd = "%svolatility -l vmi://%s --profile=%s  vadinfo --output=json --output-file=%s 2>&1 -p %ld";
-  const size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
-  char *cmd = NULL;
-  char *cmd_prefix = "";
-  const size_t cmd_max = PAGE_SIZE;
-  char *filepath = NULL;
+    // vmi_pid_t is int32_t which can be int or long
+    // so, for pid, we use %ld and cast to long
+    const char *vaddump_cmd = "%svolatility -l vmi://%s --profile=%s vaddump -D %s 2>&1 -p %ld";
+    const char *vadinfo_cmd = "%svolatility -l vmi://%s --profile=%s  vadinfo --output=json --output-file=%s 2>&1 -p %ld";
+    const size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
+    char *cmd = NULL;
+    char *cmd_prefix = "";
+    const size_t cmd_max = PAGE_SIZE;
+    char *filepath = NULL;
 
-  static int dump_count = 0;
+    static int dump_count = 0;
 
-  cmd = malloc(cmd_max);
-  filepath = malloc(PATH_MAX);
+    cmd = malloc(cmd_max);
+    filepath = malloc(PATH_MAX);
 
-  // vaddump
-  snprintf(cmd, cmd_max-1, vaddump_cmd, cmd_prefix, domain_name, vol_profile, output_dir, (long)pid);
-  snprintf(filepath, PATH_MAX - 1, "%s/vaddump_output.%04d.%ld", output_dir, dump_count, (long)pid);
-  capture_cmd(cmd, filepath);
+    // vaddump
+    snprintf(cmd, cmd_max - 1, vaddump_cmd, cmd_prefix, domain_name, vol_profile, output_dir, (long)pid);
+    snprintf(filepath, PATH_MAX - 1, "%s/vaddump_output.%04d.%ld", output_dir, dump_count, (long)pid);
+    capture_cmd(cmd, filepath);
 
-  // vadinfo
-  snprintf(filepath, PATH_MAX - 1, "%s/vadinfo.%04d.%ld.json", output_dir, dump_count, (long)pid);
-  snprintf(cmd, cmd_max-1, vadinfo_cmd, cmd_prefix, domain_name, vol_profile, filepath, (long)pid);
-  snprintf(filepath, PATH_MAX - 1, "%s/vadinfo_output.%04d.%ld", output_dir, dump_count, (long)pid);
-  capture_cmd(cmd, filepath);
+    // vadinfo
+    snprintf(filepath, PATH_MAX - 1, "%s/vadinfo.%04d.%ld.json", output_dir, dump_count, (long)pid);
+    snprintf(cmd, cmd_max - 1, vadinfo_cmd, cmd_prefix, domain_name, vol_profile, filepath, (long)pid);
+    snprintf(filepath, PATH_MAX - 1, "%s/vadinfo_output.%04d.%ld", output_dir, dump_count, (long)pid);
+    capture_cmd(cmd, filepath);
 
-  dump_count++;
-  free(cmd);
-  free(filepath);
+    dump_count++;
+    free(cmd);
+    free(filepath);
 }

--- a/src/rekall_parser.c
+++ b/src/rekall_parser.c
@@ -123,6 +123,7 @@ bool parse_rekall_windows(windows_rekall_t *rekall, char *json_file)
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['UniqueProcessId'][0]", root, &rekall->eprocess_pid);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['InheritedFromUniqueProcessId'][0]", root, &rekall->eprocess_parent_pid);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['ActiveProcessLinks'][0]", root, &rekall->eprocess_tasks);
+    set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['ObjectTable'][0]", root, &rekall->eprocess_objecttable);
     set_rekall_val("$['$STRUCTS']['_EPROCESS'][1]['VadRoot'][0]", root, &rekall->eprocess_vadroot);
     set_rekall_val("$['$STRUCTS']['_MMVAD'][1]['LeftChild'][0]", root, &rekall->mmvad_leftchild);
     set_rekall_val("$['$STRUCTS']['_MMVAD'][1]['RightChild'][0]", root, &rekall->mmvad_rightchild);

--- a/test/unit.c
+++ b/test/unit.c
@@ -77,6 +77,7 @@ void test_windows_rekall()
     CU_ASSERT(rekall.eprocess_pid == 384);
     CU_ASSERT(rekall.eprocess_parent_pid == 656);
     CU_ASSERT(rekall.eprocess_vadroot == 1096);
+    CU_ASSERT(rekall.eprocess_objecttable == 512);
     CU_ASSERT(rekall.mmvad_leftchild == 8);
     CU_ASSERT(rekall.mmvad_rightchild == 16);
     CU_ASSERT(rekall.mmvad_startingvpn == 24);


### PR DESCRIPTION
By using volatility, we save a lot of time and effort by not having to reimplement the same logic to detect VADs, extract VAD info, read bytes out of user space, etc. Going forward, vmi-unpack will only contain enough VMI logic to detect write-then-execute and relevant meta-events, like the target process exiting.